### PR TITLE
Fix deleting mods that has the same name that support different Minecraft versions

### DIFF
--- a/src/service/utils.rs
+++ b/src/service/utils.rs
@@ -381,6 +381,10 @@ async fn update_mods_to_support_a_mc_version(body: &Value, current_mc_mods: &mut
         let old_file_name = current_mc_mod.file_name.to_owned();
         let new_file_name = file.get("filename").and_then(Value::as_str).unwrap();
 
+        if old_file_name == new_file_name {
+            return;
+        }
+
         current_mc_mod.file_name = new_file_name.to_owned();
         current_mc_mod.download_url = file.get("url").and_then(Value::as_str).unwrap().to_owned();
 
@@ -389,6 +393,14 @@ async fn update_mods_to_support_a_mc_version(body: &Value, current_mc_mods: &mut
             minecraft_mod_new_version: current_mc_mod.clone(),
         });
     });
+
+    if mc_mods_version_update.is_empty() {
+        println!(
+            "\r\n{}",
+            "Mod(s) already has the correct version!".bright_green()
+        );
+        return;
+    }
 
     update_all(&mc_mods_version_update).await;
 }


### PR DESCRIPTION
closes #1 

Changes:
- Check if the old name and the new name of the mod is the same, ignore it
- If everything is ignored, tell user it's already has the correct version.

Release Notes:
- fixed: Updating mods that has the same filename as the newer `Minecraft version` now adds correctly. Mods are checked if the current filename is the same as the new filename.